### PR TITLE
Add email notification on form share

### DIFF
--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -26,9 +26,9 @@ namespace DynamicFormsApp.Client.Services
             await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy)
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy)
         {
-            var payload = new { toEmail, formName, formId, sharedBy };
+            var payload = new { toEmail, firstName, formName, description, formId, sharedBy };
             await _httpClient.PostAsJsonAsync("api/email/formshare", payload);
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -26,9 +26,9 @@ namespace DynamicFormsApp.Client.Services
             await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy)
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail)
         {
-            var payload = new { toEmail, firstName, formName, description, formId, sharedBy };
+            var payload = new { toEmail, firstName, formName, description, formId, sharedBy, ownerEmail };
             await _httpClient.PostAsJsonAsync("api/email/formshare", payload);
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -26,9 +26,9 @@ namespace DynamicFormsApp.Client.Services
             await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string formName, int formId)
+        public async Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy)
         {
-            var payload = new { toEmail, formName, formId };
+            var payload = new { toEmail, formName, formId, sharedBy };
             await _httpClient.PostAsJsonAsync("api/email/formshare", payload);
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -25,5 +25,11 @@ namespace DynamicFormsApp.Client.Services
             var payload = new { toEmail, formName, formId };
             await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
         }
+
+        public async Task SendFormShareNotification(string toEmail, string formName, int formId)
+        {
+            var payload = new { toEmail, formName, formId };
+            await _httpClient.PostAsJsonAsync("api/email/formshare", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -7,6 +7,6 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task SendBugReportEmail(EmailModel email);
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
-        Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy);
+        Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy);
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -7,6 +7,6 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task SendBugReportEmail(EmailModel email);
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
-        Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy);
+        Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail);
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -7,5 +7,6 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task SendBugReportEmail(EmailModel email);
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
+        Task SendFormShareNotification(string toEmail, string formName, int formId);
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -7,6 +7,6 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task SendBugReportEmail(EmailModel email);
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
-        Task SendFormShareNotification(string toEmail, string formName, int formId);
+        Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy);
     }
 }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -33,7 +33,7 @@ namespace DynamicFormsApp.Server.Controllers
         [HttpPost("formshare")]
         public async Task<IActionResult> SendFormShareEmail([FromBody] FormShareNotification model)
         {
-            await _emailService.SendFormShareNotification(model.toEmail, model.formName, model.formId, model.sharedBy);
+            await _emailService.SendFormShareNotification(model.toEmail, model.firstName, model.formName, model.description, model.formId, model.sharedBy);
             return Ok();
         }
 
@@ -47,7 +47,9 @@ namespace DynamicFormsApp.Server.Controllers
         public class FormShareNotification
         {
             public string toEmail { get; set; }
+            public string firstName { get; set; }
             public string formName { get; set; }
+            public string? description { get; set; }
             public int formId { get; set; }
             public string sharedBy { get; set; }
         }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -30,7 +30,21 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok();
         }
 
+        [HttpPost("formshare")]
+        public async Task<IActionResult> SendFormShareEmail([FromBody] FormShareNotification model)
+        {
+            await _emailService.SendFormShareNotification(model.toEmail, model.formName, model.formId);
+            return Ok();
+        }
+
         public class FormResponseNotification
+        {
+            public string toEmail { get; set; }
+            public string formName { get; set; }
+            public int formId { get; set; }
+        }
+
+        public class FormShareNotification
         {
             public string toEmail { get; set; }
             public string formName { get; set; }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -33,7 +33,7 @@ namespace DynamicFormsApp.Server.Controllers
         [HttpPost("formshare")]
         public async Task<IActionResult> SendFormShareEmail([FromBody] FormShareNotification model)
         {
-            await _emailService.SendFormShareNotification(model.toEmail, model.formName, model.formId);
+            await _emailService.SendFormShareNotification(model.toEmail, model.formName, model.formId, model.sharedBy);
             return Ok();
         }
 
@@ -49,6 +49,7 @@ namespace DynamicFormsApp.Server.Controllers
             public string toEmail { get; set; }
             public string formName { get; set; }
             public int formId { get; set; }
+            public string sharedBy { get; set; }
         }
     }
 }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -33,7 +33,7 @@ namespace DynamicFormsApp.Server.Controllers
         [HttpPost("formshare")]
         public async Task<IActionResult> SendFormShareEmail([FromBody] FormShareNotification model)
         {
-            await _emailService.SendFormShareNotification(model.toEmail, model.firstName, model.formName, model.description, model.formId, model.sharedBy);
+            await _emailService.SendFormShareNotification(model.toEmail, model.firstName, model.formName, model.description, model.formId, model.sharedBy, model.ownerEmail);
             return Ok();
         }
 
@@ -52,6 +52,7 @@ namespace DynamicFormsApp.Server.Controllers
             public string? description { get; set; }
             public int formId { get; set; }
             public string sharedBy { get; set; }
+            public string ownerEmail { get; set; }
         }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -219,9 +219,11 @@ namespace DynamicFormsApp.Server.Controllers
 
             var target = await _userSvc.GetUserData(dto.UserName);
             var form = await _svc.GetFormAsync(id);
+            var sender = await _userSvc.GetUserData(user);
+            var sharedBy = sender?.DisplayName ?? user;
             if (target != null && !string.IsNullOrEmpty(target.Email))
             {
-                await _emailSvc.SendFormShareNotification(target.Email, form.Name, form.Id);
+                await _emailSvc.SendFormShareNotification(target.Email, form.Name, form.Id, sharedBy);
             }
 
             return NoContent();

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -223,7 +223,8 @@ namespace DynamicFormsApp.Server.Controllers
             var sharedBy = sender?.DisplayName ?? user;
             if (target != null && !string.IsNullOrEmpty(target.Email))
             {
-                await _emailSvc.SendFormShareNotification(target.Email, form.Name, form.Id, sharedBy);
+                var firstName = target.DisplayName?.Split(' ').FirstOrDefault() ?? target.UserName;
+                await _emailSvc.SendFormShareNotification(target.Email, firstName, form.Name, form.Description, form.Id, sharedBy);
             }
 
             return NoContent();

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -224,7 +224,8 @@ namespace DynamicFormsApp.Server.Controllers
             if (target != null && !string.IsNullOrEmpty(target.Email))
             {
                 var firstName = target.DisplayName?.Split(' ').FirstOrDefault() ?? target.UserName;
-                await _emailSvc.SendFormShareNotification(target.Email, firstName, form.Name, form.Description, form.Id, sharedBy);
+                var ownerEmail = sender?.Email ?? string.Empty;
+                await _emailSvc.SendFormShareNotification(target.Email, firstName, form.Name, form.Description, form.Id, sharedBy, ownerEmail);
             }
 
             return NoContent();

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -216,6 +216,14 @@ namespace DynamicFormsApp.Server.Controllers
             }
 
             await _svc.ShareFormAsync(id, user, dto.UserName);
+
+            var target = await _userSvc.GetUserData(dto.UserName);
+            var form = await _svc.GetFormAsync(id);
+            if (target != null && !string.IsNullOrEmpty(target.Email))
+            {
+                await _emailSvc.SendFormShareNotification(target.Email, form.Name, form.Id);
+            }
+
             return NoContent();
         }
 

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -73,22 +73,30 @@ namespace DynamicFormsApp.Server.Services
             await client.SendMailAsync(mail);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy)
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy)
         {
             var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
             var formLink = $"{baseUrl}/forms/{formId}";
+
+            var support = _configuration["Email:Support"] ?? _configuration["Email:From"] ?? "support@example.com";
+
+            var greeting = string.IsNullOrWhiteSpace(firstName) ? "Hello" : $"Hi {firstName}";
+
+            var descBlock = string.IsNullOrWhiteSpace(description) ? string.Empty : $"<p>{description}</p>";
 
             var mail = new MailMessage
             {
                 From = new MailAddress(_configuration["Email:From"] ?? "noreply@example.com"),
                 Subject = $"{sharedBy} shared a form with you",
-                Body = $@"<div style='font-family:sans-serif;font-size:14px'>
+                Body = $@"<div style='font-family:sans-serif;font-size:14px;line-height:1.5'>
+                            <p>{greeting},</p>
                             <p><strong>{sharedBy}</strong> has shared the form <strong>{formName}</strong> with you.</p>
-                            <p style='text-align:center'>
-                                <a href='{formLink}' style='display:inline-block;padding:10px 15px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>Open Form</a>
+                            {descBlock}
+                            <p style='text-align:center;margin:20px 0'>
+                                <a href='{formLink}' style='display:inline-block;padding:10px 20px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>👉 View the Form</a>
                             </p>
-                            <hr style='border:none;border-top:1px solid #ddd'/>
-                            <p style='font-size:12px;color:#555'>This is an automated message, please do not reply.</p>
+                            <p>If you have any questions, contact us at <a href='mailto:{support}'>{support}</a>.</p>
+                            <p style='font-size:12px;color:#555'>If you weren\u2019t expecting this, ignore this email or contact us.</p>
                         </div>",
                 IsBodyHtml = true
             };

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -73,12 +73,11 @@ namespace DynamicFormsApp.Server.Services
             await client.SendMailAsync(mail);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy)
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail)
         {
             var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
             var formLink = $"{baseUrl}/forms/{formId}";
 
-            var support = _configuration["Email:Support"] ?? _configuration["Email:From"] ?? "support@example.com";
 
             var greeting = string.IsNullOrWhiteSpace(firstName) ? "Hello" : $"Hi {firstName}";
 
@@ -86,7 +85,7 @@ namespace DynamicFormsApp.Server.Services
 
             var mail = new MailMessage
             {
-                From = new MailAddress(_configuration["Email:From"] ?? "noreply@example.com"),
+                From = new MailAddress(string.IsNullOrWhiteSpace(ownerEmail) ? (_configuration["Email:From"] ?? "noreply@example.com") : ownerEmail),
                 Subject = $"{sharedBy} shared a form with you",
                 Body = $@"<div style='font-family:sans-serif;font-size:14px;line-height:1.5'>
                             <p>{greeting},</p>
@@ -95,7 +94,7 @@ namespace DynamicFormsApp.Server.Services
                             <p style='text-align:center;margin:20px 0'>
                                 <a href='{formLink}' style='display:inline-block;padding:10px 20px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>👉 View the Form</a>
                             </p>
-                            <p>If you have any questions, contact us at <a href='mailto:{support}'>{support}</a>.</p>
+                            <p>If you have any questions, contact me at <a href='mailto:{ownerEmail}'>{ownerEmail}</a>.</p>
                             <p style='font-size:12px;color:#555'>If you weren\u2019t expecting this, ignore this email or contact us.</p>
                         </div>",
                 IsBodyHtml = true

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -72,5 +72,28 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormShareNotification(string toEmail, string formName, int formId)
+        {
+            var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var formLink = $"{baseUrl}/forms/{formId}";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress(_configuration["Email:From"] ?? "noreply@example.com"),
+                Subject = $"A form '{formName}' has been shared with you",
+                Body = $@"<p style='font-family:sans-serif;font-size:14px'>The form <strong>{formName}</strong> has been shared with you.</p>
+                        <p><a href='{formLink}' style='display:inline-block;padding:8px 12px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>Open Form</a></p>",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -73,7 +73,7 @@ namespace DynamicFormsApp.Server.Services
             await client.SendMailAsync(mail);
         }
 
-        public async Task SendFormShareNotification(string toEmail, string formName, int formId)
+        public async Task SendFormShareNotification(string toEmail, string formName, int formId, string sharedBy)
         {
             var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
             var formLink = $"{baseUrl}/forms/{formId}";
@@ -81,9 +81,15 @@ namespace DynamicFormsApp.Server.Services
             var mail = new MailMessage
             {
                 From = new MailAddress(_configuration["Email:From"] ?? "noreply@example.com"),
-                Subject = $"A form '{formName}' has been shared with you",
-                Body = $@"<p style='font-family:sans-serif;font-size:14px'>The form <strong>{formName}</strong> has been shared with you.</p>
-                        <p><a href='{formLink}' style='display:inline-block;padding:8px 12px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>Open Form</a></p>",
+                Subject = $"{sharedBy} shared a form with you",
+                Body = $@"<div style='font-family:sans-serif;font-size:14px'>
+                            <p><strong>{sharedBy}</strong> has shared the form <strong>{formName}</strong> with you.</p>
+                            <p style='text-align:center'>
+                                <a href='{formLink}' style='display:inline-block;padding:10px 15px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>Open Form</a>
+                            </p>
+                            <hr style='border:none;border-top:1px solid #ddd'/>
+                            <p style='font-size:12px;color:#555'>This is an automated message, please do not reply.</p>
+                        </div>",
                 IsBodyHtml = true
             };
 


### PR DESCRIPTION
## Summary
- notify user via EmailService when a form is shared
- support new `SendFormShareNotification` in email interfaces and proxy
- expose new `/api/email/formshare` endpoint

## Testing
- `dotnet build DynamicFormsApp.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711fe4cf408329a043011432556f79