### PR TITLE
Improve form share email

### DIFF
--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -25,5 +25,11 @@ namespace DynamicFormsApp.Client.Services
             var payload = new { toEmail, formName, formId };
             await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
         }
+
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail)
+        {
+            var payload = new { toEmail, firstName, formName, description, formId, sharedBy, ownerEmail };
+            await _httpClient.PostAsJsonAsync("api/email/formshare", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -7,5 +7,6 @@ namespace DynamicFormsApp.Shared.Services
     {
         Task SendBugReportEmail(EmailModel email);
         Task SendFormResponseNotification(string toEmail, string formName, int formId);
+        Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail);
     }
 }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -30,11 +30,29 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok();
         }
 
+        [HttpPost("formshare")]
+        public async Task<IActionResult> SendFormShareEmail([FromBody] FormShareNotification model)
+        {
+            await _emailService.SendFormShareNotification(model.toEmail, model.firstName, model.formName, model.description, model.formId, model.sharedBy, model.ownerEmail);
+            return Ok();
+        }
+
         public class FormResponseNotification
         {
             public string toEmail { get; set; }
             public string formName { get; set; }
             public int formId { get; set; }
+        }
+
+        public class FormShareNotification
+        {
+            public string toEmail { get; set; }
+            public string firstName { get; set; }
+            public string formName { get; set; }
+            public string? description { get; set; }
+            public int formId { get; set; }
+            public string sharedBy { get; set; }
+            public string ownerEmail { get; set; }
         }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -216,6 +216,18 @@ namespace DynamicFormsApp.Server.Controllers
             }
 
             await _svc.ShareFormAsync(id, user, dto.UserName);
+
+            var target = await _userSvc.GetUserData(dto.UserName);
+            var form = await _svc.GetFormAsync(id);
+            var sender = await _userSvc.GetUserData(user);
+            var sharedBy = sender?.DisplayName ?? user;
+            if (target != null && !string.IsNullOrEmpty(target.Email))
+            {
+                var firstName = target.DisplayName?.Split(' ').FirstOrDefault() ?? target.UserName;
+                var ownerEmail = sender?.Email ?? string.Empty;
+                await _emailSvc.SendFormShareNotification(target.Email, firstName, form.Name, form.Description, form.Id, sharedBy, ownerEmail);
+            }
+
             return NoContent();
         }
 

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -72,5 +72,41 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormShareNotification(string toEmail, string firstName, string formName, string? description, int formId, string sharedBy, string ownerEmail)
+        {
+            var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var formLink = $"{baseUrl}/forms/{formId}";
+
+
+            var greeting = string.IsNullOrWhiteSpace(firstName) ? "Hello" : $"Hi {firstName}";
+
+            var descBlock = string.IsNullOrWhiteSpace(description) ? string.Empty : $"<p>{description}</p>";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress(string.IsNullOrWhiteSpace(ownerEmail) ? (_configuration["Email:From"] ?? "noreply@example.com") : ownerEmail),
+                Subject = $"{sharedBy} shared a form with you",
+                Body = $@"<div style='font-family:sans-serif;font-size:14px;line-height:1.5'>
+                            <p>{greeting},</p>
+                            <p><strong>{sharedBy}</strong> has shared the form <strong>{formName}</strong> with you.</p>
+                            {descBlock}
+                            <p style='text-align:center;margin:20px 0'>
+                                <a href='{formLink}' style='display:inline-block;padding:10px 20px;background-color:#007bff;color:#fff;text-decoration:none;border-radius:4px'>👉 View the Form</a>
+                            </p>
+                            <p>If you have any questions, contact me at <a href='mailto:{ownerEmail}'>{ownerEmail}</a>.</p>
+                            <p style='font-size:12px;color:#555'>If you weren\u2019t expecting this, ignore this email or contact us.</p>
+                        </div>",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show first name of the recipient in share notifications
- include description and nicer HTML design in share email
- extend email share endpoint and DTO with extra fields
- send share emails from the form owner's address and show it in the contact line

## Testing
- `dotnet build DynamicFormsApp.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711fe4cf408329a043011432556f79